### PR TITLE
fix package distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 with open("README.md", "r") as fh:
     README = fh.read()
 


### PR DESCRIPTION
Hi!
When sources places into subdirectory, command `python setup.py format` fails with error
```
running format
Usage: black.py [OPTIONS] [SRC]...
Try "black.py -h" for help.

Error: Invalid value for "[SRC]...": Path "test-setuptools" does not exist.
error: Invalid format, please run 'python setup.py format'
```
My setup.cfg file looks like
```
[options]
zip_safe = False
packages = find:
include_package_data = True
package_dir =
    =lib
setup_requires =
    setuptools_scm
...
[options.packages.find]
where =
    lib
...
```
I`am copy-paste files detection from flake8 module and it seems to work correctly.